### PR TITLE
Heading hierarchy and language markup.

### DIFF
--- a/AmayaWX_Compilation.html
+++ b/AmayaWX_Compilation.html
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<?xml version="1.0" encoding="UTF-8"?
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>AmayaWX installation steps</title>
-  <meta name="generator" content="amaya 9.0.1, see http://www.w3.org/Amaya/"
-  />
+  <meta name="generator" content="amaya 9.0.1, see http://www.w3.org/Amaya/" />
 </head>
 
 <body>
 
 <div>
-<h3 id="What1">Compilation</h3>
+<h1 id="What1">Compilation</h1>
 
 <div>
-<h4>On Unix platforms</h4>
+<h2>On Unix platforms</h2>
 <ol>
   <li>Download full unix sources of Amaya : <br />
 
@@ -40,7 +39,7 @@
 </div>
 
 <div>
-<h4>On Windows</h4>
+<h2>On Windows</h2>
 <ol>
   <li>Download full windows sources of Amaya : <br />
 


### PR DESCRIPTION
For accessibility reasons:
- the document's default language should be marked using a lang and/or xml:lang attribute;
- the heading hierarchy should be correct (start with h1 and don't skip heading levels).
